### PR TITLE
fix bug where cancelling pending request causes it to disappear

### DIFF
--- a/src/components/RequestHistory.vue
+++ b/src/components/RequestHistory.vue
@@ -132,6 +132,9 @@ export { get_WFH_period, moreThanTwoMonths, formatRequestDate };
               <td class="col-1" v-if="request.Status == 'Rejected'">
                 <BBadge pill variant="danger">Rejected</BBadge>
               </td>
+              <td class="col-1" v-if="request.Status == 'Cancelled'">
+                <BBadge pill variant="secondary">Cancelled</BBadge>
+              </td>
               <td class="col-3">{{ request.Comments }}</td>
             </tr>
           </tbody>

--- a/src/components/__tests__/staffrequeststatus.test.js
+++ b/src/components/__tests__/staffrequeststatus.test.js
@@ -183,7 +183,7 @@ describe('StaffRequestStatus.vue', () => {
       expect(wrapper.vm.modalMessage).toBe(
         'Request has been successfully cancelled.',
       );
-      expect(wrapper.vm.localRequests.length).toBe(0);
+      expect(wrapper.vm.localRequests.length).toBe(1);
 
       await updateSheet(testId, 'Passed');
     } catch (error) {

--- a/src/views/staff/StaffRequestStatus.vue
+++ b/src/views/staff/StaffRequestStatus.vue
@@ -274,9 +274,13 @@ const cancelRequest = async (requestID) => {
       { params: { requestID } },
     );
 
-    localRequests.value = localRequests.value.filter(
-      (request) => request.Request_ID !== requestID,
+    const request = localRequests.value.find(
+      (request) => request.Request_ID === requestID,
     );
+
+    if (request) {
+      request.Status = 'Cancelled';
+    }
 
     showAlert('Success', `Request has been successfully cancelled.`);
   } catch (error) {

--- a/updateGoogleSheet.js
+++ b/updateGoogleSheet.js
@@ -50,7 +50,7 @@ export async function updateSheet(testId, status) {
     const rowIndex = rows.findIndex((row) => row[0] === testId);
 
     if (rowIndex !== -1) {
-      const rowNumber = rowIndex + 3;
+      const rowNumber = rowIndex + 2;
       const statusRange = `UNITTESTS!K${rowNumber}`;
       const dateRange = `UNITTESTS!P${rowNumber}`;
 


### PR DESCRIPTION
- Current behavior causes the request row to disappear once you confirm cancellation of pending request
- After fix, request stays present in the table with correct "Cancelled" banner
- Added badge to account for "Cancelled" status for request history page